### PR TITLE
feat: add example parameter to Action::param method

### DIFF
--- a/src/Platform/Action.php
+++ b/src/Platform/Action.php
@@ -168,9 +168,10 @@ abstract class Action
      * @param  array  $injections
      * @param  bool  $skipValidation
      * @param  bool  $deprecated
+     * @param  string  $example
      * @return self
      */
-    public function param(string $key, mixed $default, Validator|callable $validator, string $description = '', bool $optional = false, array $injections = [], bool $skipValidation = false, bool $deprecated = false): self
+    public function param(string $key, mixed $default, Validator|callable $validator, string $description = '', bool $optional = false, array $injections = [], bool $skipValidation = false, bool $deprecated = false, string $example = ''): self
     {
         $param = [
             'default' => $default,
@@ -180,6 +181,7 @@ abstract class Action
             'injections' => $injections,
             'skipValidation' => $skipValidation,
             'deprecated' => $deprecated, // TODO: @Meldiron implement tests
+            'example' => $example,
         ];
         $this->options['param:'.$key] = array_merge($param, ['type' => 'param']);
         $this->params[$key] = $param;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now add example values to action parameters. These examples are included in parameter configuration and can be displayed in UIs or documentation to guide users.
  * Fully backward compatible; existing configurations continue to work without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->