### PR TITLE
fix: forward deprecated and example param fields from Action to Route

### DIFF
--- a/src/Platform/Platform.php
+++ b/src/Platform/Platform.php
@@ -115,7 +115,7 @@ abstract class Platform
                     switch ($option['type']) {
                         case 'param':
                             $key = substr($key, stripos($key, ':') + 1);
-                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation']);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example']);
                             break;
                         case 'injection':
                             $hook->inject($option['name']);
@@ -165,7 +165,7 @@ abstract class Platform
                     switch ($option['type']) {
                         case 'param':
                             $key = substr($key, stripos($key, ':') + 1);
-                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation']);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example']);
                             break;
                         case 'injection':
                             $hook->inject($option['name']);
@@ -222,7 +222,7 @@ abstract class Platform
                     switch ($option['type']) {
                         case 'param':
                             $key = substr($key, stripos($key, ':') + 1);
-                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation']);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example']);
                             break;
                         case 'injection':
                             $hook->inject($option['name']);

--- a/tests/Platform/TestActionWithParams.php
+++ b/tests/Platform/TestActionWithParams.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Utopia\Tests;
+
+use Utopia\Platform\Action;
+use Utopia\Validator\Boolean;
+use Utopia\Validator\Range;
+use Utopia\Validator\Text;
+
+class TestActionWithParams extends Action
+{
+    public function __construct()
+    {
+        $this->httpPath = '/with-params';
+        $this->httpMethod = 'GET';
+
+        $this
+            ->param('name', '', new Text(128), 'User name.', false, example: 'John Doe')
+            ->param('age', 0, new Range(0, 150), 'User age.', true, example: '25')
+            ->param('active', false, new Boolean(true), 'Is active.', true, deprecated: true, example: 'true')
+            ->inject('response')
+            ->callback(function ($name, $age, $active, $response) {
+                $response->send('OK');
+            });
+    }
+}

--- a/tests/Platform/TestService.php
+++ b/tests/Platform/TestService.php
@@ -13,5 +13,6 @@ class TestService extends Service
         $this->addAction('chunked', new TestActionChunked());
         $this->addAction('redirect', new TestActionRedirect());
         $this->addAction('initHook', new TestActionInit());
+        $this->addAction('withParams', new TestActionWithParams());
     }
 }

--- a/tests/e2e/HTTPServicesTest.php
+++ b/tests/e2e/HTTPServicesTest.php
@@ -106,4 +106,37 @@ class HttpServicesTest extends TestCase
         $this->assertEquals('Hello World!', $result);
         $this->assertEquals('', ($response1->getHeaders()['x-init'] ?? ''));
     }
+
+    public function testActionParamFieldsForwardedToRoute()
+    {
+        $routes = Http::getRoutes();
+
+        $route = null;
+        foreach ($routes as $method => $methodRoutes) {
+            foreach ($methodRoutes as $r) {
+                if ($r->getPath() === '/with-params') {
+                    $route = $r;
+                    break 2;
+                }
+            }
+        }
+
+        $this->assertNotNull($route, 'Route /with-params should be registered');
+
+        $params = $route->getParams();
+
+        // Verify all Action::param() fields are forwarded to the Route
+        $actionParamKeys = ['default', 'validator', 'description', 'optional', 'injections', 'skipValidation', 'deprecated', 'example'];
+
+        foreach ($params as $name => $param) {
+            foreach ($actionParamKeys as $key) {
+                $this->assertArrayHasKey($key, $param, "Param '{$name}' is missing '{$key}' on the Route. Platform must forward all Action param fields.");
+            }
+        }
+
+        $this->assertEquals('John Doe', $params['name']['example']);
+        $this->assertFalse($params['name']['deprecated']);
+        $this->assertEquals('true', $params['active']['example']);
+        $this->assertTrue($params['active']['deprecated']);
+    }
 }


### PR DESCRIPTION
## Summary

- `Platform::initHttp()`, `initTasks()`, and `initWorker()` were not forwarding `deprecated` and `example` fields when copying Action params to Route/Hook params
- This caused SDK spec generation to lose custom `example` values defined on route parameters, producing minimal/default values in generated SDK docs instead of realistic examples
- Added test to ensure all Action param fields are forwarded to Route, preventing future regressions

## Test plan

- [x] `composer format` passes
- [x] `composer lint` passes
- [x] `composer test` passes (6 tests, 38 assertions)
- [ ] Verify SDK spec generation produces correct `x-example` values after updating this dependency