### PR TITLE
Support utopia-php/http 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "ext-redis": "*",
         "utopia-php/cli": "0.23.3",
-        "utopia-php/http": "0.34.25",
+        "utopia-php/http": "^2.0@RC",
         "utopia-php/queue": "0.18.2",
         "utopia-php/servers": "0.4.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5b594cb7190724df576883925c53acb",
+    "content-hash": "868bcc1f169d0621b90602b16361831a",
     "packages": [
         {
             "name": "brick/math",
@@ -2327,16 +2327,16 @@
         },
         {
             "name": "utopia-php/http",
-            "version": "0.34.25",
+            "version": "2.0.0-rc1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "76be330d4197bae680eb4ccc29c573456fe91904"
+                "reference": "3e3b431d443844c6bf810120dee735f45880856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/76be330d4197bae680eb4ccc29c573456fe91904",
-                "reference": "76be330d4197bae680eb4ccc29c573456fe91904",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/3e3b431d443844c6bf810120dee735f45880856f",
+                "reference": "3e3b431d443844c6bf810120dee735f45880856f",
                 "shasum": ""
             },
             "require": {
@@ -2377,9 +2377,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/0.34.25"
+                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc1"
             },
-            "time": "2026-05-05T04:39:15+00:00"
+            "time": "2026-05-05T15:00:03+00:00"
         },
         {
             "name": "utopia-php/pools",
@@ -4521,7 +4521,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "utopia-php/http": 5
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## Summary
- Bump `utopia-php/http` constraint to `^2.0@RC` so 2.0.0-rc1 (and future RCs / stable 2.x) resolve.
- Update `composer.lock` accordingly.

## Test plan
- [ ] `composer install` resolves cleanly
- [ ] `composer test` passes against http 2.0.0-rc1

🤖 Generated with [Claude Code](https://claude.com/claude-code)