### PR TITLE
chore: relax utopia-php version constraints to allow patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "php": ">=8.3",
         "ext-json": "*",
         "ext-redis": "*",
-        "utopia-php/cli": "0.23.3",
+        "utopia-php/cli": "0.23.*",
         "utopia-php/http": "^2.0@RC",
-        "utopia-php/queue": "0.18.2",
-        "utopia-php/servers": "0.4.0"
+        "utopia-php/queue": "0.18.*",
+        "utopia-php/servers": "0.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "868bcc1f169d0621b90602b16361831a",
+    "content-hash": "7a013a6f9eec8fc648647b7d0657346e",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
## Summary
- Relax `utopia-php/cli`, `utopia-php/queue`, and `utopia-php/servers` to the `x.x.*` pattern so patch releases can be picked up without composer.json changes.
- `utopia-php/http` is left as `^2.0@RC` since 2.0 is still pre-stable.

## Test plan
- [ ] `composer update` resolves without errors
- [ ] `composer test` passes