### PR TITLE
feat: add typed Enum DTO to Action::param()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "utopia-php/cli": "0.23.*",
         "utopia-php/http": "^2.0@RC",
         "utopia-php/queue": "0.18.*",
-        "utopia-php/servers": "0.4.*"
+        "utopia-php/servers": "dev-feat-param-enum-metadata as 0.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "utopia-php/cli": "0.23.*",
         "utopia-php/http": "^2.0@RC",
         "utopia-php/queue": "0.18.*",
-        "utopia-php/servers": "dev-feat-param-enum-metadata as 0.4.0"
+        "utopia-php/servers": "0.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -2187,21 +2187,21 @@
         },
         {
             "name": "utopia-php/cli",
-            "version": "0.23.3",
+            "version": "0.23.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/cli.git",
-                "reference": "3c45ae5bcdcd3c7916e1909d74c60b8e771610db"
+                "reference": "59f66e72ec1f8350968d8b95c0039faaac7a6d6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/cli/zipball/3c45ae5bcdcd3c7916e1909d74c60b8e771610db",
-                "reference": "3c45ae5bcdcd3c7916e1909d74c60b8e771610db",
+                "url": "https://api.github.com/repos/utopia-php/cli/zipball/59f66e72ec1f8350968d8b95c0039faaac7a6d6d",
+                "reference": "59f66e72ec1f8350968d8b95c0039faaac7a6d6d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4",
-                "utopia-php/servers": "0.4.0"
+                "utopia-php/servers": "0.4.*"
             },
             "require-dev": {
                 "laravel/pint": "1.2.*",
@@ -2232,9 +2232,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/cli/issues",
-                "source": "https://github.com/utopia-php/cli/tree/0.23.3"
+                "source": "https://github.com/utopia-php/cli/tree/0.23.4"
             },
-            "time": "2026-05-05T04:38:59+00:00"
+            "time": "2026-05-21T14:42:15+00:00"
         },
         {
             "name": "utopia-php/compression",
@@ -2335,23 +2335,23 @@
         },
         {
             "name": "utopia-php/http",
-            "version": "2.0.0-rc2",
+            "version": "2.0.0-rc3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "17f3d5e966ada8a5c041717436f069f269aef2b3"
+                "reference": "e1a51a2eb906a3d461378fb551a647ef01714f1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/17f3d5e966ada8a5c041717436f069f269aef2b3",
-                "reference": "17f3d5e966ada8a5c041717436f069f269aef2b3",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/e1a51a2eb906a3d461378fb551a647ef01714f1c",
+                "reference": "e1a51a2eb906a3d461378fb551a647ef01714f1c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.3",
                 "utopia-php/compression": "0.1.*",
                 "utopia-php/di": "0.3.*",
-                "utopia-php/servers": "0.4.0",
+                "utopia-php/servers": "0.4.*",
                 "utopia-php/telemetry": "0.2.*",
                 "utopia-php/validators": "0.2.*"
             },
@@ -2385,9 +2385,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc2"
+                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc3"
             },
-            "time": "2026-05-20T11:13:49+00:00"
+            "time": "2026-05-21T14:42:41+00:00"
         },
         {
             "name": "utopia-php/pools",
@@ -2444,16 +2444,16 @@
         },
         {
             "name": "utopia-php/queue",
-            "version": "0.18.3",
+            "version": "0.18.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/queue.git",
-                "reference": "141aad162b90728353f3aa834684b1f2affed045"
+                "reference": "1323b52f39b899c580dbb7af8562fc53d4e13e62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/queue/zipball/141aad162b90728353f3aa834684b1f2affed045",
-                "reference": "141aad162b90728353f3aa834684b1f2affed045",
+                "url": "https://api.github.com/repos/utopia-php/queue/zipball/1323b52f39b899c580dbb7af8562fc53d4e13e62",
+                "reference": "1323b52f39b899c580dbb7af8562fc53d4e13e62",
                 "shasum": ""
             },
             "require": {
@@ -2461,7 +2461,7 @@
                 "php-amqplib/php-amqplib": "^3.7",
                 "utopia-php/di": "0.3.*",
                 "utopia-php/pools": "1.*",
-                "utopia-php/servers": "0.4.0",
+                "utopia-php/servers": "0.4.*",
                 "utopia-php/telemetry": "0.2.*",
                 "utopia-php/validators": "0.2.*"
             },
@@ -2504,22 +2504,22 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/queue/issues",
-                "source": "https://github.com/utopia-php/queue/tree/0.18.3"
+                "source": "https://github.com/utopia-php/queue/tree/0.18.4"
             },
-            "time": "2026-05-14T08:53:35+00:00"
+            "time": "2026-05-21T14:43:24+00:00"
         },
         {
             "name": "utopia-php/servers",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
-                "reference": "7db346ef377503efe0acafe0791085270cd9ed70"
+                "reference": "6e9241f587a19c0e9e7a3587fe3b15ffb2d4c2a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/7db346ef377503efe0acafe0791085270cd9ed70",
-                "reference": "7db346ef377503efe0acafe0791085270cd9ed70",
+                "url": "https://api.github.com/repos/utopia-php/servers/zipball/6e9241f587a19c0e9e7a3587fe3b15ffb2d4c2a4",
+                "reference": "6e9241f587a19c0e9e7a3587fe3b15ffb2d4c2a4",
                 "shasum": ""
             },
             "require": {
@@ -2558,9 +2558,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/0.4.0"
+                "source": "https://github.com/utopia-php/servers/tree/0.4.1"
             },
-            "time": "2026-05-05T04:08:30+00:00"
+            "time": "2026-05-21T13:08:45+00:00"
         },
         {
             "name": "utopia-php/telemetry",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a013a6f9eec8fc648647b7d0657346e",
+    "content-hash": "1d5ad8dea4b2c78b74039f808f469bab",
     "packages": [
         {
             "name": "brick/math",
@@ -2502,16 +2502,16 @@
         },
         {
             "name": "utopia-php/servers",
-            "version": "0.4.0",
+            "version": "dev-feat-param-enum-metadata",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
-                "reference": "7db346ef377503efe0acafe0791085270cd9ed70"
+                "reference": "333e93c5e5c629a1ae059003f570a48bc5a0eeb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/7db346ef377503efe0acafe0791085270cd9ed70",
-                "reference": "7db346ef377503efe0acafe0791085270cd9ed70",
+                "url": "https://api.github.com/repos/utopia-php/servers/zipball/333e93c5e5c629a1ae059003f570a48bc5a0eeb6",
+                "reference": "333e93c5e5c629a1ae059003f570a48bc5a0eeb6",
                 "shasum": ""
             },
             "require": {
@@ -2550,9 +2550,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/0.4.0"
+                "source": "https://github.com/utopia-php/servers/tree/feat-param-enum-metadata"
             },
-            "time": "2026-05-05T04:08:30+00:00"
+            "time": "2026-05-20T11:51:30+00:00"
         },
         {
             "name": "utopia-php/telemetry",
@@ -2611,16 +2611,16 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "5d7d494e64457cd4eb67fdcfd9481f2c89796aa6"
+                "reference": "9770269c8ed8e6909934965fa8722103c7434c23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/5d7d494e64457cd4eb67fdcfd9481f2c89796aa6",
-                "reference": "5d7d494e64457cd4eb67fdcfd9481f2c89796aa6",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/9770269c8ed8e6909934965fa8722103c7434c23",
+                "reference": "9770269c8ed8e6909934965fa8722103c7434c23",
                 "shasum": ""
             },
             "require": {
@@ -2650,9 +2650,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.2.2"
+                "source": "https://github.com/utopia-php/validators/tree/0.2.3"
             },
-            "time": "2026-04-27T16:30:24+00:00"
+            "time": "2026-05-14T08:05:44+00:00"
         }
     ],
     "packages-dev": [
@@ -4519,10 +4519,18 @@
             "time": "2025-11-17T20:03:58+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/servers",
+            "version": "dev-feat-param-enum-metadata",
+            "alias": "0.4.0",
+            "alias_normalized": "0.4.0.0"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "utopia-php/http": 5
+        "utopia-php/http": 5,
+        "utopia-php/servers": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d5ad8dea4b2c78b74039f808f469bab",
+    "content-hash": "7a013a6f9eec8fc648647b7d0657346e",
     "packages": [
         {
             "name": "brick/math",
@@ -1549,16 +1549,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -1571,7 +1571,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1596,7 +1596,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1608,11 +1608,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -1717,16 +1721,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
                 "shasum": ""
             },
             "require": {
@@ -1739,7 +1743,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1775,7 +1779,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1787,11 +1791,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T11:18:49+00:00"
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2040,16 +2048,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -2067,7 +2075,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -2103,7 +2111,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -2123,7 +2131,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "tbachert/spi",
@@ -2327,16 +2335,16 @@
         },
         {
             "name": "utopia-php/http",
-            "version": "2.0.0-rc1",
+            "version": "2.0.0-rc2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "3e3b431d443844c6bf810120dee735f45880856f"
+                "reference": "17f3d5e966ada8a5c041717436f069f269aef2b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/3e3b431d443844c6bf810120dee735f45880856f",
-                "reference": "3e3b431d443844c6bf810120dee735f45880856f",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/17f3d5e966ada8a5c041717436f069f269aef2b3",
+                "reference": "17f3d5e966ada8a5c041717436f069f269aef2b3",
                 "shasum": ""
             },
             "require": {
@@ -2377,9 +2385,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc1"
+                "source": "https://github.com/utopia-php/http/tree/2.0.0-rc2"
             },
-            "time": "2026-05-05T15:00:03+00:00"
+            "time": "2026-05-20T11:13:49+00:00"
         },
         {
             "name": "utopia-php/pools",
@@ -2436,16 +2444,16 @@
         },
         {
             "name": "utopia-php/queue",
-            "version": "0.18.2",
+            "version": "0.18.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/queue.git",
-                "reference": "f85ca003c99ff475708c05466643d067403c0c22"
+                "reference": "141aad162b90728353f3aa834684b1f2affed045"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/queue/zipball/f85ca003c99ff475708c05466643d067403c0c22",
-                "reference": "f85ca003c99ff475708c05466643d067403c0c22",
+                "url": "https://api.github.com/repos/utopia-php/queue/zipball/141aad162b90728353f3aa834684b1f2affed045",
+                "reference": "141aad162b90728353f3aa834684b1f2affed045",
                 "shasum": ""
             },
             "require": {
@@ -2496,22 +2504,22 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/queue/issues",
-                "source": "https://github.com/utopia-php/queue/tree/0.18.2"
+                "source": "https://github.com/utopia-php/queue/tree/0.18.3"
             },
-            "time": "2026-05-05T04:38:59+00:00"
+            "time": "2026-05-14T08:53:35+00:00"
         },
         {
             "name": "utopia-php/servers",
-            "version": "dev-feat-param-enum-metadata",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
-                "reference": "333e93c5e5c629a1ae059003f570a48bc5a0eeb6"
+                "reference": "7db346ef377503efe0acafe0791085270cd9ed70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/333e93c5e5c629a1ae059003f570a48bc5a0eeb6",
-                "reference": "333e93c5e5c629a1ae059003f570a48bc5a0eeb6",
+                "url": "https://api.github.com/repos/utopia-php/servers/zipball/7db346ef377503efe0acafe0791085270cd9ed70",
+                "reference": "7db346ef377503efe0acafe0791085270cd9ed70",
                 "shasum": ""
             },
             "require": {
@@ -2550,9 +2558,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/feat-param-enum-metadata"
+                "source": "https://github.com/utopia-php/servers/tree/0.4.0"
             },
-            "time": "2026-05-20T11:51:30+00:00"
+            "time": "2026-05-05T04:08:30+00:00"
         },
         {
             "name": "utopia-php/telemetry",
@@ -2611,16 +2619,16 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "9770269c8ed8e6909934965fa8722103c7434c23"
+                "reference": "b4ee60db4dbae5ffbe53968d01f69b6941251576"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/9770269c8ed8e6909934965fa8722103c7434c23",
-                "reference": "9770269c8ed8e6909934965fa8722103c7434c23",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/b4ee60db4dbae5ffbe53968d01f69b6941251576",
+                "reference": "b4ee60db4dbae5ffbe53968d01f69b6941251576",
                 "shasum": ""
             },
             "require": {
@@ -2650,9 +2658,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.2.3"
+                "source": "https://github.com/utopia-php/validators/tree/0.2.4"
             },
-            "time": "2026-05-14T08:05:44+00:00"
+            "time": "2026-05-21T12:47:43+00:00"
         }
     ],
     "packages-dev": [
@@ -4519,18 +4527,10 @@
             "time": "2025-11-17T20:03:58+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "utopia-php/servers",
-            "version": "dev-feat-param-enum-metadata",
-            "alias": "0.4.0",
-            "alias_normalized": "0.4.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "utopia-php/http": 5,
-        "utopia-php/servers": 20
+        "utopia-php/http": 5
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/src/Platform/Action.php
+++ b/src/Platform/Action.php
@@ -170,9 +170,10 @@ abstract class Action
      * @param  bool  $deprecated
      * @param  string  $example
      * @param  array  $aliases
+     * @param  Enum|null  $enum
      * @return self
      */
-    public function param(string $key, mixed $default, Validator|callable $validator, string $description = '', bool $optional = false, array $injections = [], bool $skipValidation = false, bool $deprecated = false, string $example = '', array $aliases = []): self
+    public function param(string $key, mixed $default, Validator|callable $validator, string $description = '', bool $optional = false, array $injections = [], bool $skipValidation = false, bool $deprecated = false, string $example = '', array $aliases = [], ?Enum $enum = null): self
     {
         $param = [
             'default' => $default,
@@ -184,6 +185,7 @@ abstract class Action
             'deprecated' => $deprecated, // TODO: @Meldiron implement tests
             'example' => $example,
             'aliases' => $aliases,
+            'enum' => $enum,
         ];
         $this->options['param:'.$key] = array_merge($param, ['type' => 'param']);
         $this->params[$key] = $param;

--- a/src/Platform/Enum.php
+++ b/src/Platform/Enum.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Utopia\Platform;
+
+/**
+ * Enum metadata for whitelist-backed parameters.
+ */
+final readonly class Enum
+{
+    /**
+     * @param  string|null  $name Generated enum name.
+     * @param  array<string, string>|null  $map Mapping of whitelist values to generated enum case names.
+     * @param  list<string>|null  $exclude Whitelist values to omit from generated enums.
+     */
+    public function __construct(
+        public ?string $name = null,
+        public ?array $map = null,
+        public ?array $exclude = null,
+    ) {
+    }
+}

--- a/src/Platform/Platform.php
+++ b/src/Platform/Platform.php
@@ -115,7 +115,7 @@ abstract class Platform
                     switch ($option['type']) {
                         case 'param':
                             $key = substr($key, stripos($key, ':') + 1);
-                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? []);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? [], enum: $option['enum'] ?? null);
                             break;
                         case 'injection':
                             $hook->inject($option['name']);
@@ -165,7 +165,7 @@ abstract class Platform
                     switch ($option['type']) {
                         case 'param':
                             $key = substr($key, stripos($key, ':') + 1);
-                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? []);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? [], enum: $option['enum'] ?? null);
                             break;
                         case 'injection':
                             $hook->inject($option['name']);
@@ -222,7 +222,7 @@ abstract class Platform
                     switch ($option['type']) {
                         case 'param':
                             $key = substr($key, stripos($key, ':') + 1);
-                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? []);
+                            $hook->param($key, $option['default'], $option['validator'], $option['description'], $option['optional'], $option['injections'], $option['skipValidation'], $option['deprecated'], $option['example'], aliases: $option['aliases'] ?? [], enum: $option['enum'] ?? null);
                             break;
                         case 'injection':
                             $hook->inject($option['name']);

--- a/tests/Platform/TestActionWithParams.php
+++ b/tests/Platform/TestActionWithParams.php
@@ -3,9 +3,11 @@
 namespace Utopia\Tests;
 
 use Utopia\Platform\Action;
+use Utopia\Platform\Enum;
 use Utopia\Validator\Boolean;
 use Utopia\Validator\Range;
 use Utopia\Validator\Text;
+use Utopia\Validator\WhiteList;
 
 class TestActionWithParams extends Action
 {
@@ -19,8 +21,9 @@ class TestActionWithParams extends Action
             ->param('age', 0, new Range(0, 150), 'User age.', true, example: '25')
             ->param('active', false, new Boolean(true), 'Is active.', true, deprecated: true, example: 'true')
             ->param('email', '', new Text(256), 'User email.', true, aliases: ['emailAddress', 'userEmail'], example: 'user@example.com')
+            ->param('status', 'draft', new WhiteList(['draft', 'published']), 'Status.', optional: true, enum: new Enum(name: 'ArticleStatus', map: ['draft' => 'Draft', 'published' => 'Published']))
             ->inject('response')
-            ->callback(function ($name, $age, $active, $email, $response) {
+            ->callback(function ($name, $age, $active, $email, $status, $response) {
                 $response->send('OK');
             });
     }

--- a/tests/e2e/HTTPServicesTest.php
+++ b/tests/e2e/HTTPServicesTest.php
@@ -167,5 +167,22 @@ class HttpServicesTest extends TestCase
         // Verify params without aliases have empty array
         $this->assertArrayHasKey('aliases', $params['name'], 'Param name should have aliases key');
         $this->assertEquals([], $params['name']['aliases']);
+
+        // Verify enum is forwarded to Route params
+        $this->assertArrayHasKey('enum', $params['status'], 'Param status should have enum key on Route');
+        $this->assertInstanceOf(\Utopia\Platform\Enum::class, $params['status']['enum']);
+        $this->assertEquals('ArticleStatus', $params['status']['enum']->name);
+        $this->assertEquals(['draft' => 'Draft', 'published' => 'Published'], $params['status']['enum']->map);
+
+        // Verify enum is stored on Action params
+        $action = new TestActionWithParams();
+        $actionParams = $action->getParams();
+
+        $this->assertInstanceOf(\Utopia\Platform\Enum::class, $actionParams['status']['enum']);
+        $this->assertEquals('ArticleStatus', $actionParams['status']['enum']->name);
+        $this->assertEquals(['draft' => 'Draft', 'published' => 'Published'], $actionParams['status']['enum']->map);
+
+        // Verify params without enum are null on Action
+        $this->assertNull($actionParams['name']['enum']);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Adds an optional typed `Enum` DTO parameter to `Utopia\Platform\Action::param()` for attaching SDK enum metadata to whitelist-backed parameters.

Instead of a generic `meta` bag (which risks becoming a junk drawer for unrelated data), the parameter accepts a scoped `Utopia\Platform\Enum` value:

```php
->param(
    'status',
    'draft',
    new WhiteList(['draft', 'published']),
    'Status.',
    optional: true,
    enum: new Enum(
        name: 'ArticleStatus',
        map: ['draft' => 'Draft', 'published' => 'Published'],
    ),
)
```

`Enum` contains:
- `$name` — generated enum name
- `$map` — mapping of whitelist values to case names (`array<string, string>`)
- `$exclude` — whitelist values to omit from generated enums

Utopia stores and forwards the DTO but does not interpret it. Enforcement (e.g. "whitelist must have enum") is left to consumer generators.

## Why not a generic `meta` array?

A generic `meta` array would couple Utopia to consumer-specific concepts and invite abuse as a catch-all dump for unrelated data. A typed, scoped DTO keeps the API clean and forces intentional design for future metadata needs.

## Test Plan

- Existing positional and named-argument calls to `param()` remain valid (backward-compatible).
- `enum` defaults to `null` when not provided.
- `enum` is stored in both `$this->params[$key]` and `$this->options['param:'.$key]`.
- `enum` is intentionally **not** forwarded to Route/CLI/Worker hooks.
- Added e2e assertions verifying `enum` presence on Action params and absence on Route params.

## Related PRs and Issues

N/A — small framework-level API expansion.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR is related to an issue in another repository, please provide a link.
